### PR TITLE
Allow iOS apps to override which view controller is used to present the share dialog

### DIFF
--- a/ios/Classes/ShareExtendPlugin.h
+++ b/ios/Classes/ShareExtendPlugin.h
@@ -1,4 +1,9 @@
 #import <Flutter/Flutter.h>
 
+@protocol ShareExtendPluginDelegate <NSObject>
+@optional
+- (UIViewController*)presentingViewControllerForShareExtend;
+@end
+
 @interface ShareExtendPlugin : NSObject<FlutterPlugin>
 @end

--- a/ios/Classes/ShareExtendPlugin.m
+++ b/ios/Classes/ShareExtendPlugin.m
@@ -59,7 +59,13 @@
 + (void)share:(NSArray *)sharedItems atSource:(CGRect)origin withSubject:(NSString *) subject {
     UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:sharedItems applicationActivities:nil];
     
-    UIViewController *controller =[UIApplication sharedApplication].keyWindow.rootViewController;
+    UIViewController *controller = [UIApplication sharedApplication].keyWindow.rootViewController;
+    
+    if ([[[UIApplication sharedApplication] delegate] respondsToSelector:@selector(presentingViewControllerForShareExtend)]) {
+        id<ShareExtendPluginDelegate> delegate = [[UIApplication sharedApplication] delegate];
+        controller = [delegate presentingViewControllerForShareExtend];
+    }
+        
     activityViewController.popoverPresentationController.sourceView = controller.view;
 
     if (CGRectIsEmpty(origin)) {


### PR DESCRIPTION
My FlutterViewController is not `[UIApplication sharedApplication].keyWindow.rootViewController` (I am running a hybrid native/Flutter app) so I couldn't get the share dialog to appear. So I allowed it to be overridden/customised.