### PR TITLE
Attempt to fix present UIActivityViewController on ViewController

### DIFF
--- a/ios/Classes/ShareExtendPlugin.m
+++ b/ios/Classes/ShareExtendPlugin.m
@@ -60,6 +60,12 @@
     UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:sharedItems applicationActivities:nil];
     
     UIViewController *controller =[UIApplication sharedApplication].keyWindow.rootViewController;
+    
+    // obtain top presented viewController
+    while (controller.presentedViewController) {
+        controller = controller.presentedViewController;
+    }
+    
     activityViewController.popoverPresentationController.sourceView = controller.view;
 
     if (CGRectIsEmpty(origin)) {


### PR DESCRIPTION
Scene: present a ViewController with sharing ability, UIActivityViewController can not be shown.

Log message: Attempt to present <UIActivityViewController> on <ViewController> whose view is not in the window hierarchy

Solution: find out the top presented ViewController to present UIActivityViewController.